### PR TITLE
Added Documentation support to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@
   - supports windows, mac, and linux
   - python 3.7 - above
 
+[**Documentation**](https://cbedroid.github.io/pydatpiff/) is still undergoing, but you can still visit it here.
+
+**Full documentation** will be available soon!
+
 ## Dependencies
 
 **PyDatpiff requires:**


### PR DESCRIPTION
cbedroid/pydatpiff nosisse

Added Documentation [link](https://cbedroid.github.io/pydatpiff/)  to README. 

